### PR TITLE
fix: add missing @types/uuid dependency

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.68.0",
         "@google/generative-ai": "^0.1.3",
-        "@types/uuid": "^10.0.0",
         "axios": "^1.6.2",
         "chalk": "^4.1.2",
         "chart.js": "^4.5.1",
@@ -34,6 +33,7 @@
         "@types/inquirer": "^8.2.10",
         "@types/jest": "^29.5.14",
         "@types/js-yaml": "^4.0.9",
+        "@types/uuid": "^9.0.8",
         "jest": "^29.7.0",
         "ts-jest": "^29.4.5",
         "typescript": "^5.3.3"
@@ -1207,9 +1207,10 @@
       }
     },
     "node_modules/@types/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/yargs": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -25,7 +25,6 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.68.0",
     "@google/generative-ai": "^0.1.3",
-    "@types/uuid": "^10.0.0",
     "axios": "^1.6.2",
     "chalk": "^4.1.2",
     "chart.js": "^4.5.1",
@@ -45,6 +44,7 @@
     "@types/inquirer": "^8.2.10",
     "@types/jest": "^29.5.14",
     "@types/js-yaml": "^4.0.9",
+    "@types/uuid": "^9.0.8",
     "jest": "^29.7.0",
     "ts-jest": "^29.4.5",
     "typescript": "^5.3.3"


### PR DESCRIPTION
- Install @types/uuid@9.0.8 to match uuid@9.0.1
- Resolves TypeScript error: Cannot find module 'uuid'
- All tests still passing (73/73)
- Build completes successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies to optimize the build toolchain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->