### PR TITLE
chore(cli): ESLint tooling and local artifact gitignore

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,5 +1,1 @@
 buy_me_a_coffee: ntanwir10
-github: []
-patreon: []
-open_collective: []
-ko_fi: []

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,8 @@ ci-netrc
 cli/scripts/*
 cli/scripts/update-act-cache.sh
 cli/scripts/ACT_USAGE.md
+
+# Local GuardScan scan output and agent plan copies
+.guardscan/
+*.plan.md
+cli/test_results.txt

--- a/cli/.eslintignore
+++ b/cli/.eslintignore
@@ -1,0 +1,7 @@
+dist/
+node_modules/
+coverage/
+**/*.js
+**/*.d.ts
+__tests__/
+

--- a/cli/.eslintrc.json
+++ b/cli/.eslintrc.json
@@ -3,7 +3,7 @@
   "parserOptions": {
     "ecmaVersion": 2020,
     "sourceType": "module",
-    "project": "./tsconfig.json"
+    "project": true
   },
   "plugins": ["@typescript-eslint"],
   "extends": [

--- a/cli/.eslintrc.json
+++ b/cli/.eslintrc.json
@@ -1,0 +1,51 @@
+{
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": 2020,
+    "sourceType": "module",
+    "project": "./tsconfig.json"
+  },
+  "plugins": ["@typescript-eslint"],
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:@typescript-eslint/recommended-requiring-type-checking"
+  ],
+  "rules": {
+    "@typescript-eslint/no-explicit-any": "error",
+    "@typescript-eslint/explicit-function-return-type": "off",
+    "@typescript-eslint/explicit-module-boundary-types": "off",
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      {
+        "argsIgnorePattern": "^_",
+        "varsIgnorePattern": "^_"
+      }
+    ],
+    "@typescript-eslint/no-floating-promises": "error",
+    "@typescript-eslint/no-misused-promises": "error",
+    "no-console": [
+      "warn",
+      {
+        "allow": ["warn", "error"]
+      }
+    ],
+    "prefer-const": "error",
+    "no-var": "error",
+    "eqeqeq": ["error", "always"],
+    "curly": ["error", "all"],
+    "no-throw-literal": "error"
+  },
+  "env": {
+    "node": true,
+    "es2020": true
+  },
+  "ignorePatterns": [
+    "dist/",
+    "node_modules/",
+    "coverage/",
+    "**/*.js",
+    "**/*.d.ts"
+  ]
+}
+


### PR DESCRIPTION
## Summary
- Add `cli/.eslintrc.json` and `cli/.eslintignore` for TypeScript linting
- Ignore local `.guardscan/`, `*.plan.md`, and `cli/test_results.txt` in `.gitignore`
- Trim empty placeholder entries from `.github/FUNDING.yml`

## Test plan
- [x] No runtime changes; config-only PR
- [x] After merge, follow-up PR adds ESLint devDependencies and `lint` scripts


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated repository funding options to add a new payment handle.
  * Expanded ignore patterns to exclude local tooling outputs, test artifacts, and generated files.
  * Added and tightened linting configuration for the CLI to enforce stricter TypeScript and code-quality rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->