### PR TITLE
feat(cli): route observability through GuardScan-Monitoring API

### DIFF
--- a/cli/__tests__/utils/monitoring.test.ts
+++ b/cli/__tests__/utils/monitoring.test.ts
@@ -1,0 +1,48 @@
+import axios from 'axios';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { MonitoringManager } from '../../src/utils/monitoring';
+
+jest.mock('axios');
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('MonitoringManager', () => {
+  const originalGuardscanHome = process.env.GUARDSCAN_HOME;
+  let tempHome: string;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'guardscan-monitoring-'));
+    process.env.GUARDSCAN_HOME = tempHome;
+  });
+
+  afterEach(() => {
+    if (originalGuardscanHome === undefined) {
+      delete process.env.GUARDSCAN_HOME;
+    } else {
+      process.env.GUARDSCAN_HOME = originalGuardscanHome;
+    }
+    fs.rmSync(tempHome, { recursive: true, force: true });
+  });
+
+  it('skips usage tracking when the local config has not been initialized', async () => {
+    const manager = new MonitoringManager({
+      enabled: true,
+      endpoint: 'https://monitoring.example',
+      errorReportingEnabled: true,
+      performanceMonitoringEnabled: true,
+      usageAnalyticsEnabled: true,
+      sampleRate: 1.0,
+    });
+
+    await expect(
+      manager.trackUsage('security', 250, true, { source: 'test' })
+    ).resolves.toBeUndefined();
+    await manager.flush();
+    await manager.shutdown();
+
+    expect(mockedAxios.post).not.toHaveBeenCalled();
+  });
+});

--- a/cli/package.json
+++ b/cli/package.json
@@ -37,7 +37,7 @@
     "url": "https://github.com/ntanwir10/GuardScan.git",
     "directory": "cli"
   },
-  "homepage": "http://guardscancli.com",
+  "homepage": "https://guardscancli.com",
   "bugs": {
     "url": "https://github.com/ntanwir10/GuardScan/issues"
   },

--- a/cli/src/commands/cache.ts
+++ b/cli/src/commands/cache.ts
@@ -19,41 +19,48 @@ export function createCacheCommand(): Command {
     .command('stats')
     .description('Show cache statistics')
     .action(async () => {
-      const repo = new Repository(process.cwd());
-      const repoId = repo.getId();
-      const config = configManager.loadOrInit();
+      try {
+        const repo = new Repository(process.cwd());
+        const repoId = repo.getId();
+        const config = configManager.loadOrInit();
 
-      const cache = new AICache(repoId, config.cache?.maxSizeMB || 100);
-      const stats = cache.getStats();
+        const cache = new AICache(repoId, config.cache?.maxSizeMB || 100);
+        const stats = cache.getStats();
+        const sizeMB = cache.getSizeMB();
+        const utilization = cache.getUtilization();
 
-      console.log(chalk.bold('\n💾 Cache Statistics\n'));
-      console.log('─'.repeat(60));
+        console.log(chalk.bold('\n💾 Cache Statistics\n'));
+        console.log('─'.repeat(60));
 
-      console.log(chalk.bold('Usage:'));
-      console.log(`  Total Entries:  ${stats.totalEntries}`);
-      console.log(`  Cache Size:     ${cache.getSizeMB().toFixed(2)} MB`);
-      console.log(`  Max Size:       ${config.cache?.maxSizeMB || 100} MB`);
-      console.log(`  Utilization:    ${cache.getUtilization().toFixed(1)}%`);
+        console.log(chalk.bold('Usage:'));
+        console.log(`  Total Entries:  ${stats.totalEntries}`);
+        console.log(`  Cache Size:     ${sizeMB.toFixed(2)} MB`);
+        console.log(`  Max Size:       ${config.cache?.maxSizeMB || 100} MB`);
+        console.log(`  Utilization:    ${utilization.toFixed(1)}%`);
 
-      const utilizationBar = createProgressBar(cache.getUtilization());
-      console.log(`  Progress:       ${utilizationBar}`);
+        const utilizationBar = createProgressBar(utilization);
+        console.log(`  Progress:       ${utilizationBar}`);
 
-      console.log(chalk.bold('\nPerformance:'));
-      console.log(`  Cache Hits:     ${stats.hits}`);
-      console.log(`  Cache Misses:   ${stats.misses}`);
-      console.log(`  Hit Rate:       ${stats.hitRate.toFixed(1)}%`);
+        console.log(chalk.bold('\nPerformance:'));
+        console.log(`  Cache Hits:     ${stats.hits}`);
+        console.log(`  Cache Misses:   ${stats.misses}`);
+        console.log(`  Hit Rate:       ${stats.hitRate.toFixed(1)}%`);
 
-      if (stats.hitRate > 0) {
-        const savingsPercent = stats.hitRate;
-        console.log(chalk.green(`  💰 Estimated savings: ~${savingsPercent.toFixed(0)}% of API costs`));
+        if (stats.hitRate > 0) {
+          const savingsPercent = stats.hitRate;
+          console.log(chalk.green(`  💰 Estimated savings: ~${savingsPercent.toFixed(0)}% of API costs`));
+        }
+
+        console.log(chalk.bold('\nConfiguration:'));
+        console.log(`  Enabled:            ${config.cache?.enabled !== false ? '✅' : '❌'}`);
+        console.log(`  Semantic Threshold: ${config.cache?.semanticThreshold || 0.95}`);
+        console.log(`  TTL:                ${config.cache?.ttlSeconds || 3600}s`);
+
+        console.log('\n');
+      } catch (error) {
+        console.error(chalk.red(`Failed to read cache stats: ${getErrorMessage(error)}`));
+        process.exitCode = 1;
       }
-
-      console.log(chalk.bold('\nConfiguration:'));
-      console.log(`  Enabled:            ${config.cache?.enabled !== false ? '✅' : '❌'}`);
-      console.log(`  Semantic Threshold: ${config.cache?.semanticThreshold || 0.95}`);
-      console.log(`  TTL:                ${config.cache?.ttlSeconds || 3600}s`);
-
-      console.log('\n');
     });
 
   // Cache info
@@ -93,14 +100,19 @@ export function createCacheCommand(): Command {
         return;
       }
 
-      const repo = new Repository(process.cwd());
-      const repoId = repo.getId();
-      const config = configManager.loadOrInit();
+      try {
+        const repo = new Repository(process.cwd());
+        const repoId = repo.getId();
+        const config = configManager.loadOrInit();
 
-      const cache = new AICache(repoId, config.cache?.maxSizeMB || 100);
-      await cache.clear();
+        const cache = new AICache(repoId, config.cache?.maxSizeMB || 100);
+        await cache.clear();
 
-      console.log(chalk.green('✅ Cache cleared\n'));
+        console.log(chalk.green('✅ Cache cleared\n'));
+      } catch (error) {
+        console.error(chalk.red(`Failed to clear cache: ${getErrorMessage(error)}`));
+        process.exitCode = 1;
+      }
     });
 
   return command;
@@ -120,4 +132,8 @@ function createProgressBar(percent: number): string {
   }
 
   return '[' + color('█'.repeat(filled)) + '░'.repeat(empty) + ']';
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }

--- a/cli/src/core/cost-guard.ts
+++ b/cli/src/core/cost-guard.ts
@@ -234,7 +234,7 @@ export class CostGuard {
   /**
    * Export usage data
    */
-  async exportUsage(outputPath: string, days: number = 30): Promise<void> {
+  exportUsage(outputPath: string, days: number = 30): void {
     this.usage.exportToCSV(outputPath, days);
   }
 

--- a/cli/src/utils/api-client.ts
+++ b/cli/src/utils/api-client.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosInstance } from "axios";
 import { API_CONSTANTS } from "../constants/api-constants";
+import { getGuardscanMonitoringBaseUrl } from "./monitoring-base-url";
 
 export interface TelemetryEvent {
   action: string;
@@ -25,10 +26,7 @@ export class APIClient {
     // Default backend for project-wide telemetry (optional, privacy-preserving)
     // Users can opt-out with --no-telemetry flag
     // Or override with GUARDSCAN_API_URL env var (for testing/self-hosting)
-    this.baseUrl =
-      baseUrl ||
-      process.env.GUARDSCAN_API_URL ||
-      API_CONSTANTS.DEFAULT_API_BASE_URL;
+    this.baseUrl = baseUrl || getGuardscanMonitoringBaseUrl();
 
     this.client = axios.create({
       baseURL: this.baseUrl,

--- a/cli/src/utils/monitoring-base-url.ts
+++ b/cli/src/utils/monitoring-base-url.ts
@@ -1,0 +1,10 @@
+import { API_CONSTANTS } from "../constants/api-constants";
+
+/**
+ * Base URL for the GuardScan-Monitoring Cloudflare Worker (telemetry + monitoring).
+ * Same host backs POST /api/telemetry and POST /api/monitoring.
+ */
+export function getGuardscanMonitoringBaseUrl(): string {
+  const raw = process.env.GUARDSCAN_API_URL || API_CONSTANTS.DEFAULT_API_BASE_URL;
+  return raw.replace(/\/$/, "");
+}

--- a/cli/src/utils/monitoring.ts
+++ b/cli/src/utils/monitoring.ts
@@ -1,19 +1,17 @@
 /**
  * Monitoring & Analytics Module
  *
- * Integrates with Cloudflare Analytics and provides error tracking
- * P0: Critical Before Launch
- *
- * Features:
- * - Error tracking and reporting
- * - Performance monitoring
- * - Usage analytics
- * - Health checks
+ * Remote payloads are POSTed to the GuardScan-Monitoring Worker
+ * (`GUARDSCAN_API_URL` / default `api.guardscancli.com`): `/api/monitoring` and
+ * health checks `/api/health`. Same host as anonymized telemetry batching via
+ * `api-client` → `/api/telemetry`.
  */
 
 import axios from 'axios';
 import * as os from 'os';
+import type { Config } from '../core/config';
 import { ConfigManager } from '../core/config';
+import { getGuardscanMonitoringBaseUrl } from './monitoring-base-url';
 
 /**
  * Error Severity Levels
@@ -113,16 +111,34 @@ export class MonitoringManager {
   private usageBuffer: UsageEvent[] = [];
   private flushInterval: NodeJS.Timeout | null = null;
 
-  constructor(config?: MonitoringConfig) {
+  constructor(custom?: MonitoringConfig) {
     this.configManager = new ConfigManager();
 
-    this.config = config || {
-      enabled: true,
+    let yaml: Config | null = null;
+    try {
+      if (this.configManager.exists()) yaml = this.configManager.load();
+    } catch {
+      yaml = null;
+    }
+
+    const noTelemetryCli = process.env.GUARDSCAN_NO_TELEMETRY === 'true';
+    const telemetryOn = Boolean(yaml?.telemetryEnabled && !noTelemetryCli);
+    const offline = Boolean(yaml?.offlineMode);
+    const remoteAllowed = telemetryOn && !offline;
+    const inferredEndpoint = remoteAllowed ? getGuardscanMonitoringBaseUrl() : undefined;
+
+    const merged: MonitoringConfig = {
+      enabled: telemetryOn,
+      endpoint: inferredEndpoint,
       errorReportingEnabled: true,
       performanceMonitoringEnabled: true,
       usageAnalyticsEnabled: true,
-      sampleRate: 1.0
+      sampleRate: 1.0,
+      ...custom,
     };
+    merged.endpoint = custom?.endpoint ?? inferredEndpoint;
+
+    this.config = merged;
 
     // Auto-flush every 30 seconds
     this.startAutoFlush();

--- a/cli/src/utils/monitoring.ts
+++ b/cli/src/utils/monitoring.ts
@@ -123,7 +123,7 @@ export class MonitoringManager {
 
     const noTelemetryCli = process.env.GUARDSCAN_NO_TELEMETRY === 'true';
     const telemetryOn = Boolean(yaml?.telemetryEnabled && !noTelemetryCli);
-    const offline = Boolean(yaml?.offlineMode);
+    const offline = yaml?.offlineMode ?? true;
     const remoteAllowed = telemetryOn && !offline;
     const inferredEndpoint = remoteAllowed ? getGuardscanMonitoringBaseUrl() : undefined;
 

--- a/cli/src/utils/monitoring.ts
+++ b/cli/src/utils/monitoring.ts
@@ -129,14 +129,13 @@ export class MonitoringManager {
 
     const merged: MonitoringConfig = {
       enabled: telemetryOn,
-      endpoint: inferredEndpoint,
       errorReportingEnabled: true,
       performanceMonitoringEnabled: true,
       usageAnalyticsEnabled: true,
       sampleRate: 1.0,
       ...custom,
+      endpoint: custom?.endpoint ?? inferredEndpoint,
     };
-    merged.endpoint = custom?.endpoint ?? inferredEndpoint;
 
     this.config = merged;
 

--- a/cli/src/utils/monitoring.ts
+++ b/cli/src/utils/monitoring.ts
@@ -229,7 +229,12 @@ export class MonitoringManager {
       return;
     }
 
-    const userConfig = this.configManager.load();
+    let userConfig;
+    try {
+      userConfig = this.configManager.load();
+    } catch {
+      return;
+    }
 
     const usageEvent: UsageEvent = {
       eventId: this.generateId(),


### PR DESCRIPTION
## Summary
- Add `getGuardscanMonitoringBaseUrl()` helper (`GUARDSCAN_API_URL` or default `api.guardscancli.com`)
- Point telemetry client and monitoring manager at the GuardScan-Monitoring worker
- Respect `telemetryEnabled`, `offlineMode`, and `GUARDSCAN_NO_TELEMETRY` when inferring remote endpoints

**Stacks on:** #29

## Test plan
- [x] Build and tests pass on stacked branch
- [x] With telemetry enabled, confirm POSTs reach `api.guardscancli.com/api/telemetry` and `/api/monitoring`
- [x] With `--no-telemetry` / offline mode, confirm no remote endpoint is configured

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized how the CLI determines and initializes the monitoring backend endpoint configuration.
  * Improved separation of concerns for endpoint discovery and telemetry configuration management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->